### PR TITLE
Add grade column to wrong_answers; filter by grade

### DIFF
--- a/migrations/002_wrong_answers_grade.sql
+++ b/migrations/002_wrong_answers_grade.sql
@@ -1,0 +1,7 @@
+-- Add grade column to wrong_answers so wrong answers are isolated per grade
+ALTER TABLE wrong_answers
+  ADD COLUMN IF NOT EXISTS grade integer NOT NULL DEFAULT 3;
+
+UPDATE wrong_answers SET grade = 3 WHERE grade IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_wrong_answers_grade ON wrong_answers(student, grade, subject);


### PR DESCRIPTION
## Summary
- The `wrong_answers` table was missing a `grade` column, so the `grade=eq.${studentGrade}` filter added in the previous commit was silently ignored by PostgREST — all 18 grade 3 wrong answers were still showing in 4th grade mode
- Migration `002_wrong_answers_grade.sql` adds `grade integer NOT NULL DEFAULT 3`, backfills existing rows to grade 3, and adds an index
- The JS already includes grade in the upsert and filters all reads by `studentGrade` (from the prior commit) — this migration is what makes that actually work

## Test plan
- [ ] Log in → pick 4th Grade → Wrong Answers button should be hidden (0 for grade 4)
- [ ] Pick 3rd Grade → Wrong Answers button should show 18
- [ ] Answer a 4th grade question wrong → switch to 3rd grade → wrong answers count should not include the new 4th grade miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)