### PR TITLE
Strip letter prefixes baked into question options

### DIFF
--- a/fix_option_letter_prefixes.py
+++ b/fix_option_letter_prefixes.py
@@ -1,0 +1,109 @@
+"""
+Strip letter prefixes baked into question option text.
+
+Uploads stored options as ["A 35", "B 100", ...]. The app shuffles options at
+render and draws its own A/B/C/D badge, so the baked-in letter and the badge
+fall out of sync as soon as the order changes - the child sees "A) D 200".
+
+Scoring is unaffected: `correct` stores letters that are remapped to the new
+position during the shuffle. Positions are untouched here, so stored `correct`
+values stay valid. This is a pure text cleanup.
+
+Detection is deliberately strict. It requires the leading letters to run
+A, B, C, D *in sequence across positions*, so legitimate text like
+["A rhyme", "A simile", "A metaphor"] is never touched - only position 0
+would match there, not positions 1 and 2.
+"""
+import json, urllib.request, sys, random
+
+BASE = "https://zvffmucghcrqackghhlf.supabase.co/rest/v1"
+KEY  = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp2ZmZtdWNnaGNycWFja2doaGxmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY3MjkyNTIsImV4cCI6MjA5MjMwNTI1Mn0.eJHX6LmInRdBd5nt9t_jBJwILGEQ6_SeN6ADorlsWic"
+H    = {"Content-Type": "application/json", "apikey": KEY, "Authorization": f"Bearer {KEY}"}
+
+LETTERS = "ABCDEFGH"
+SEPS    = (" ", ".", ")", "-", ":")
+
+DRY = "--apply" not in sys.argv
+
+
+def strip_one(opt, letter):
+    """Return the option minus a leading `<letter><sep>`, or None if absent."""
+    if not isinstance(opt, str):
+        return None
+    t = opt.lstrip()
+    if len(t) >= 2 and t[0] == letter and t[1] in SEPS:
+        return t[2:].lstrip(" .)-:")
+    return None
+
+
+def is_prefixed(options):
+    """True only when leading letters run A,B,C,D in sequence across positions."""
+    if not isinstance(options, list) or len(options) < 2:
+        return False
+    hits = sum(1 for i, o in enumerate(options)
+               if i < len(LETTERS) and strip_one(o, LETTERS[i]) is not None)
+    return hits >= max(3, len(options) - 1)
+
+
+def clean(options):
+    out = []
+    for i, o in enumerate(options):
+        s = strip_one(o, LETTERS[i]) if i < len(LETTERS) else None
+        out.append(s if s else o)
+    return out
+
+
+def fetch_all():
+    rows, off = [], 0
+    while True:
+        url = f"{BASE}/questions?select=id,grade,subject,domain,options,correct&active=eq.true&order=id&offset={off}&limit=1000"
+        req = urllib.request.Request(url, headers={"apikey": KEY, "Authorization": f"Bearer {KEY}"})
+        with urllib.request.urlopen(req) as r:
+            batch = json.loads(r.read())
+        rows += batch
+        if len(batch) < 1000:
+            return rows
+        off += 1000
+
+
+def patch(qid, options):
+    data = json.dumps({"options": options}).encode()
+    req = urllib.request.Request(f"{BASE}/questions?id=eq.{qid}", data=data,
+                                 method="PATCH", headers={**H, "Prefer": "return=minimal"})
+    with urllib.request.urlopen(req) as r:
+        return r.status
+
+
+rows = fetch_all()
+affected = [q for q in rows if is_prefixed(q.get("options"))]
+print(f"active questions : {len(rows)}")
+print(f"affected         : {len(affected)}")
+
+# Refuse to write anything that would blank an option.
+unsafe = []
+for q in affected:
+    if any(not str(o).strip() for o in clean(q["options"])):
+        unsafe.append(q["id"])
+if unsafe:
+    print(f"ABORT: {len(unsafe)} would produce an empty option, e.g. {unsafe[:3]}")
+    sys.exit(1)
+
+random.seed(7)
+print("\nsample (before -> after):")
+for q in random.sample(affected, min(8, len(affected))):
+    print(f"  {q['options']}\n   -> {clean(q['options'])}")
+
+if DRY:
+    print("\nDRY RUN. Re-run with --apply to write.")
+    sys.exit(0)
+
+ok = 0
+for i, q in enumerate(affected, 1):
+    if patch(q["id"], clean(q["options"])) in (200, 204):
+        ok += 1
+    if i % 100 == 0:
+        print(f"  {i}/{len(affected)}")
+print(f"\npatched {ok}/{len(affected)}")
+
+left = [q for q in fetch_all() if is_prefixed(q.get("options"))]
+print(f"remaining affected: {len(left)}")

--- a/tests.html
+++ b/tests.html
@@ -550,6 +550,40 @@ create policy "Allow delete wrong_answers"  on wrong_answers for delete using (t
     return `${qRows.length} passage-linked questions all have valid FKs`;
   });
 
+  await test('No active question has letter prefixes baked into its options', async () => {
+    // Options were uploaded as ["A 35","B 100",...]. The app shuffles options and
+    // draws its own A/B/C/D badge, so a baked-in letter contradicts the badge as
+    // soon as the order changes - the child reads "A) D 200". See issue #29.
+    //
+    // Strict detection: the leading letters must run A,B,C,D *in sequence across
+    // positions*. Legitimate text like ["A rhyme","A simile"] matches only at
+    // position 0, never at position 1, so it is never flagged.
+    const LETTERS = 'ABCDEFGH', SEPS = [' ', '.', ')', '-', ':'];
+    const prefixed = (o, ch) => {
+      if (typeof o !== 'string') return false;
+      const t = o.replace(/^\s+/, '');
+      return t[0] === ch && SEPS.includes(t[1]);
+    };
+    let rows = [], off = 0;
+    while (true) {
+      const res = await db(`questions?select=id,options&active=eq.true&order=id&offset=${off}&limit=1000`);
+      assert(res.ok, `HTTP ${res.status}`);
+      const batch = await res.json();
+      rows = rows.concat(batch);
+      if (batch.length < 1000) break;
+      off += 1000;
+    }
+    const bad = rows.filter(q => {
+      const o = q.options;
+      if (!Array.isArray(o) || o.length < 2) return false;
+      const hits = o.filter((v, i) => i < LETTERS.length && prefixed(v, LETTERS[i])).length;
+      return hits >= Math.max(3, o.length - 1);
+    });
+    assert(bad.length === 0,
+      `${bad.length} of ${rows.length} active questions still carry option letter prefixes (e.g. ${JSON.stringify((bad[0]||{}).options)})`);
+    return `${rows.length} active questions clean`;
+  });
+
   // ── 12–16. App Logic tests (via iframe) ───────────────────────────────────
   // Load app in a hidden iframe and wait for initApp() to complete
 

--- a/upload_4th_grade_ela_batch2.py
+++ b/upload_4th_grade_ela_batch2.py
@@ -2,10 +2,39 @@
 # Run this script from an environment with network access to Supabase, then close the issue.
 import json, urllib.request, time
 
+# ── Guard: never upload options with letter prefixes baked in ────────────
+# The app shuffles options and draws its own A/B/C/D badge, so a baked-in
+# letter contradicts the badge once the order changes. See issue #29.
+_LETTERS = "ABCDEFGH"
+_SEPS = (" ", ".", ")", "-", ":")
+
+def strip_option_prefixes(options):
+    """Drop leading '<letter><sep>' only when letters run in sequence."""
+    if not isinstance(options, list) or len(options) < 2:
+        return options
+    def cut(o, ch):
+        if not isinstance(o, str):
+            return None
+        t = o.lstrip()
+        return t[2:].lstrip(" .)-:") if len(t) >= 2 and t[0] == ch and t[1] in _SEPS else None
+    hits = sum(1 for i, o in enumerate(options) if i < len(_LETTERS) and cut(o, _LETTERS[i]) is not None)
+    if hits < max(3, len(options) - 1):
+        return options
+    out = []
+    for i, o in enumerate(options):
+        c = cut(o, _LETTERS[i]) if i < len(_LETTERS) else None
+        out.append(c if c else o)
+    return out
+
+
+
 URL = "https://zvffmucghcrqackghhlf.supabase.co/rest/v1/questions"
 KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp2ZmZtdWNnaGNycWFja2doaGxmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY3MjkyNTIsImV4cCI6MjA5MjMwNTI1Mn0.eJHX6LmInRdBd5nt9t_jBJwILGEQ6_SeN6ADorlsWic"
 
 def upload_batch(batch):
+    for q in batch:
+        if q.get("options"):
+            q["options"] = strip_option_prefixes(q["options"])
     data = json.dumps(batch).encode()
     req = urllib.request.Request(URL, data=data, method='POST')
     req.add_header('Content-Type', 'application/json')

--- a/upload_4th_grade_math_batch2.py
+++ b/upload_4th_grade_math_batch2.py
@@ -2,10 +2,39 @@
 # Run this script from an environment with network access to Supabase, then close the issue.
 import json, urllib.request, time
 
+# ── Guard: never upload options with letter prefixes baked in ────────────
+# The app shuffles options and draws its own A/B/C/D badge, so a baked-in
+# letter contradicts the badge once the order changes. See issue #29.
+_LETTERS = "ABCDEFGH"
+_SEPS = (" ", ".", ")", "-", ":")
+
+def strip_option_prefixes(options):
+    """Drop leading '<letter><sep>' only when letters run in sequence."""
+    if not isinstance(options, list) or len(options) < 2:
+        return options
+    def cut(o, ch):
+        if not isinstance(o, str):
+            return None
+        t = o.lstrip()
+        return t[2:].lstrip(" .)-:") if len(t) >= 2 and t[0] == ch and t[1] in _SEPS else None
+    hits = sum(1 for i, o in enumerate(options) if i < len(_LETTERS) and cut(o, _LETTERS[i]) is not None)
+    if hits < max(3, len(options) - 1):
+        return options
+    out = []
+    for i, o in enumerate(options):
+        c = cut(o, _LETTERS[i]) if i < len(_LETTERS) else None
+        out.append(c if c else o)
+    return out
+
+
+
 URL = "https://zvffmucghcrqackghhlf.supabase.co/rest/v1/questions"
 KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp2ZmZtdWNnaGNycWFja2doaGxmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY3MjkyNTIsImV4cCI6MjA5MjMwNTI1Mn0.eJHX6LmInRdBd5nt9t_jBJwILGEQ6_SeN6ADorlsWic"
 
 def upload_batch(batch):
+    for q in batch:
+        if q.get("options"):
+            q["options"] = strip_option_prefixes(q["options"])
     data = json.dumps(batch).encode()
     req = urllib.request.Request(URL, data=data, method='POST')
     req.add_header('Content-Type', 'application/json')


### PR DESCRIPTION
Closes #29

**860 of 2176 active questions (40%)** stored options as `["A 35","B 100","C 150","D 200"]`. The app shuffles options at render and draws its own A/B/C/D badge, so the baked-in letter contradicted the badge as soon as the order changed:

```
A    D 200
B    C 150
C    B 100
D    A 35
```

Scoring was never affected — `correct` is remapped to the new position during the shuffle. That arguably made it worse: it looked broken and taught Jaden to distrust the labels.

## Strict detection
Requires the leading letters to run **A, B, C, D in sequence across positions**, at least `n-1` of them. Verified against the cases that would break a naive regex:

| Input | Result |
|---|---|
| `["A 35","B 100","C 150","D 200"]` | stripped ✅ |
| `["A rhyme","A simile","A metaphor","A repetition"]` | untouched ✅ |
| `["A is greater (42 > 45)","B is greater","They are equal","Cannot tell"]` | untouched ✅ |

The migration also aborts rather than writing any change that would blank an option. Positions are untouched, so stored `correct` letters stay valid — pure text cleanup, no scoring migration.

## Changes
- `fix_option_letter_prefixes.py` — dry-run by default, `--apply` to write
- Guard test over the entire active bank, so this cannot silently return
- Same normaliser wired into `upload_batch()` in both batch-2 scripts

## Result
**860/860 patched, 0 remaining.** **124/124 tests pass** — guard reports "2176 active questions clean".

🤖 Generated with [Claude Code](https://claude.com/claude-code)