### PR TITLE
Progress engine: XP, levels, daily streak, badges

### DIFF
--- a/index.html
+++ b/index.html
@@ -3591,6 +3591,153 @@ async function _fetchAll(path, headers) {
   return all;
 }
 
+// ═══════════════════════════════════════════════════════════════════
+//  PROGRESS ENGINE - XP, levels, daily streak, badges
+//
+//  Everything is DERIVED from the existing attempts history rather than
+//  stored in new columns. That is deliberate: it means Jaden's past work
+//  counts the moment this ships instead of resetting him to zero, and
+//  there is no second source of truth to drift out of sync.
+//
+//  Pure functions, no DOM and no network, so tests can call them directly.
+// ═══════════════════════════════════════════════════════════════════
+
+const XP_PER_CORRECT   = 15;
+const XP_PERFECT_BONUS = 25;   // a clean set is worth more than its parts
+const PERFECT_MIN_Qs   = 5;    // ...but only if it was a real set
+
+// XP to climb one level. Gentle at the start (100, 150, 200, ...) so a new
+// player levels often, then the slope halves past level 10 so progression
+// does not stall: on real history Jaden is already level 19, and an
+// un-softened curve would have charged him ~67 correct answers per level
+// from there. Ramp: +50/level to L10, +25/level after.
+const LEVEL_RAMP_KNEE = 10;
+function xpToClearLevel(level) {
+  return level <= LEVEL_RAMP_KNEE
+    ? 100 + (level - 1) * 50
+    : 100 + (LEVEL_RAMP_KNEE - 1) * 50 + (level - LEVEL_RAMP_KNEE) * 25;
+}
+
+// Total XP required to have REACHED a given level.
+function xpAtLevelStart(level) {
+  let total = 0;
+  for (let l = 1; l < level; l++) total += xpToClearLevel(l);
+  return total;
+}
+
+function levelFromXp(xp) {
+  let level = 1;
+  while (xp >= xpAtLevelStart(level + 1)) level++;
+  return level;
+}
+
+// Local calendar day, not UTC. A 7pm session must not land on tomorrow.
+function localDayKey(ts) {
+  const d = new Date(ts);
+  if (isNaN(d)) return null;
+  const p = n => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+}
+
+function _dayKeyOffset(key, deltaDays) {
+  const [y, m, d] = key.split('-').map(Number);
+  const dt = new Date(y, m - 1, d);
+  dt.setDate(dt.getDate() + deltaDays);
+  return localDayKey(dt);
+}
+
+function xpForAttempt(a) {
+  const score = Number(a.score) || 0;
+  const total = Number(a.total) || 0;
+  let xp = score * XP_PER_CORRECT;
+  if (total >= PERFECT_MIN_Qs && score === total) xp += XP_PERFECT_BONUS;
+  return xp;
+}
+
+/**
+ * @param {Array}  attempts - rows from the attempts table
+ * @param {string} [todayKey] - injectable "today" so tests are not clock-dependent
+ */
+function computeProgress(attempts, todayKey) {
+  const done = (Array.isArray(attempts) ? attempts : [])
+    .filter(a => a && a.completed === true && (Number(a.total) || 0) > 0);
+
+  const xp    = done.reduce((sum, a) => sum + xpForAttempt(a), 0);
+  const level = levelFromXp(xp);
+
+  const start       = xpAtLevelStart(level);
+  const span        = xpToClearLevel(level);
+  const xpIntoLevel = xp - start;
+
+  // Distinct local days that have at least one completed session.
+  const days = new Set();
+  for (const a of done) {
+    const k = localDayKey(a.created_at);
+    if (k) days.add(k);
+  }
+
+  const today = todayKey || localDayKey(new Date());
+  // A streak survives until a full day is missed, so it may end today OR
+  // yesterday. Counting only from today would break every morning.
+  let cursor = days.has(today) ? today
+             : days.has(_dayKeyOffset(today, -1)) ? _dayKeyOffset(today, -1)
+             : null;
+  let dailyStreak = 0;
+  while (cursor && days.has(cursor)) {
+    dailyStreak++;
+    cursor = _dayKeyOffset(cursor, -1);
+  }
+
+  // Longest run anywhere in the history.
+  const sorted = [...days].sort();
+  let bestDailyStreak = 0, run = 0, prev = null;
+  for (const k of sorted) {
+    run = (prev && _dayKeyOffset(prev, 1) === k) ? run + 1 : 1;
+    if (run > bestDailyStreak) bestDailyStreak = run;
+    prev = k;
+  }
+
+  const questions = done.reduce((n, a) => n + (Number(a.total)  || 0), 0);
+  const correct   = done.reduce((n, a) => n + (Number(a.score)  || 0), 0);
+
+  return {
+    xp, level,
+    xpIntoLevel,
+    xpForNextLevel: span,
+    xpToNextLevel:  Math.max(0, span - xpIntoLevel),
+    levelPct: span > 0 ? Math.min(100, Math.round((xpIntoLevel / span) * 100)) : 0,
+    dailyStreak, bestDailyStreak,
+    todayDone: days.has(today),
+    activeDays: days.size,
+    sessions: done.length,
+    questions, correct,
+    accuracy: questions > 0 ? Math.round((correct / questions) * 100) : 0,
+  };
+}
+
+// Badge rules. Each is a pure predicate over the derived progress plus the
+// raw attempts, so historical work retroactively unlocks what it earned.
+const BADGE_RULES = [
+  { id:'first-steps',  name:'First Steps',    ico:'ic-play',     test:p => p.sessions   >= 1   },
+  { id:'perfect-set',  name:'Perfect Set',    ico:'ic-practice', test:(p,a) => a.some(x => (Number(x.total)||0) >= PERFECT_MIN_Qs && Number(x.score) === Number(x.total)) },
+  { id:'century',      name:'Century',        ico:'ic-chart',    test:p => p.questions  >= 100 },
+  { id:'streak-3',     name:'3-Day Streak',   ico:'ic-flame',    test:p => p.bestDailyStreak >= 3  },
+  { id:'streak-10',    name:'10-Day Streak',  ico:'ic-flame',    test:p => p.bestDailyStreak >= 10 },
+  { id:'level-5',      name:'Level 5',        ico:'ic-star',     test:p => p.level      >= 5   },
+  { id:'level-10',     name:'Level 10',       ico:'ic-trophy',   test:p => p.level      >= 10  },
+  { id:'sharpshooter', name:'Sharpshooter',   ico:'ic-practice', test:p => p.questions  >= 50 && p.accuracy >= 90 },
+  { id:'thousand',     name:'1000 XP',        ico:'ic-star',     test:p => p.xp         >= 1000 },
+  { id:'all-domains',  name:'All Domains',    ico:'ic-all',      test:(p,a) => new Set(a.filter(x=>x.completed&&x.domain).map(x=>x.domain)).size >= 5 },
+];
+
+function computeBadges(progress, attempts) {
+  const list = Array.isArray(attempts) ? attempts : [];
+  return BADGE_RULES.map(r => ({
+    id: r.id, name: r.name, ico: r.ico,
+    earned: !!r.test(progress, list),
+  }));
+}
+
 async function loadAppData() {
   const h = { 'apikey': SUPABASE_ANON, 'Authorization': `Bearer ${SUPABASE_ANON}` };
 
@@ -3630,7 +3777,9 @@ async function loadAppData() {
   // Do NOT restore student_grade here — user must pick a grade each session
 
   // Expose for tests
-  window._mcapData  = { PASSAGES, LESSON_MAP, PIN_CORRECT, PIN_PARENT, DOMAIN_COUNTS, studentGrade };
+  window._mcapData  = { PASSAGES, LESSON_MAP, PIN_CORRECT, PIN_PARENT, DOMAIN_COUNTS, studentGrade,
+                        computeProgress, computeBadges, levelFromXp, xpAtLevelStart, xpToClearLevel,
+                        xpForAttempt, localDayKey, BADGE_RULES };
   window._qKey      = _qKey;
   window.Q_CACHE    = Q_CACHE;
 }

--- a/tests.html
+++ b/tests.html
@@ -644,6 +644,130 @@ create policy "Allow delete wrong_answers"  on wrong_answers for delete using (t
   await appIframe.ensureQuestionsLoaded('Math', 'All');
   await appIframe.ensureQuestionsLoaded('Reading', 'All');
 
+  // ── Progress engine (pure functions, via iframe) ─────────────────────────
+  suite('\u{1F3AE} Progress engine \u2014 XP, levels, streaks (iframe)');
+
+  const P = appData;
+  // Synthetic day-offset attempt so streak tests never depend on the clock.
+  const mkA = (dayOffset, score = 5, total = 5) => {
+    const d = new Date();
+    d.setDate(d.getDate() + dayOffset);
+    d.setHours(19, 30, 0, 0);
+    return { completed: true, score, total, created_at: d.toISOString(), domain: 'OA' };
+  };
+  const TODAY = P.localDayKey(new Date());
+
+  await test('Level curve round-trips: xpAtLevelStart(n) maps back to level n', async () => {
+    const levels = [1, 2, 3, 5, 8, 10, 11, 15, 20, 30];
+    for (const n of levels) {
+      const back = P.levelFromXp(P.xpAtLevelStart(n));
+      assert(back === n, `level ${n} round-tripped to ${back}`);
+    }
+    return `${levels.length} levels round-trip`;
+  });
+
+  await test('Level curve is monotonic and never cheaper to climb later', async () => {
+    let prevStart = -1;
+    for (let n = 1; n <= 40; n++) {
+      const start = P.xpAtLevelStart(n);
+      assert(start > prevStart, `xpAtLevelStart(${n}) not increasing`);
+      prevStart = start;
+      assert(P.xpToClearLevel(n) > 0, `level ${n} costs nothing`);
+    }
+    return '40 levels monotonic';
+  });
+
+  await test('XP: 15 per correct, +25 bonus only for a perfect set of 5+', async () => {
+    assert(P.xpForAttempt({ score: 5, total: 5 }) === 100, 'perfect 5/5 should be 5*15+25');
+    assert(P.xpForAttempt({ score: 4, total: 4 }) === 60,  'perfect 4/4 is under the 5-question floor, no bonus');
+    assert(P.xpForAttempt({ score: 4, total: 5 }) === 60,  'imperfect set should get no bonus');
+    return '15/correct, +25 perfect-set bonus';
+  });
+
+  await test('Daily streak counts consecutive days ending today', async () => {
+    const p = P.computeProgress([mkA(0), mkA(-1), mkA(-2)], TODAY);
+    assert(p.dailyStreak === 3, `got ${p.dailyStreak}`);
+    assert(p.todayDone === true, 'todayDone should be true');
+    return 'streak = 3';
+  });
+
+  await test('Daily streak survives until a full day is missed', async () => {
+    // Ending yesterday must still count, or the streak would break every
+    // morning before the first session of the day.
+    const p = P.computeProgress([mkA(-1), mkA(-2), mkA(-3)], TODAY);
+    assert(p.dailyStreak === 3, `got ${p.dailyStreak}`);
+    assert(p.todayDone === false, 'todayDone should be false');
+    return 'streak = 3, today not yet done';
+  });
+
+  await test('Daily streak breaks after a missed day, best streak is retained', async () => {
+    const p = P.computeProgress([mkA(-2), mkA(-3), mkA(-4)], TODAY);
+    assert(p.dailyStreak === 0, `current streak should be 0, got ${p.dailyStreak}`);
+    assert(p.bestDailyStreak === 3, `best should be 3, got ${p.bestDailyStreak}`);
+    return 'current 0, best 3';
+  });
+
+  await test('Two sessions in one day count as one streak day', async () => {
+    const p = P.computeProgress([mkA(0), mkA(0), mkA(-1)], TODAY);
+    assert(p.dailyStreak === 2, `got ${p.dailyStreak}`);
+    assert(p.sessions === 3, `sessions should be 3, got ${p.sessions}`);
+    return '3 sessions across 2 days';
+  });
+
+  await test('Streak uses local calendar days, not UTC', async () => {
+    // A late-evening session must land on today, not roll into tomorrow.
+    const late = new Date(); late.setHours(23, 45, 0, 0);
+    assert(P.localDayKey(late) === TODAY, 'late-evening session drifted to another day');
+    const early = new Date(); early.setHours(0, 15, 0, 0);
+    assert(P.localDayKey(early) === TODAY, 'early-morning session drifted to another day');
+    return 'local day boundaries hold';
+  });
+
+  await test('Incomplete and zero-question attempts are excluded', async () => {
+    const noise = [
+      { completed: false, score: 9, total: 9, created_at: new Date().toISOString() },
+      { completed: true,  score: 0, total: 0, created_at: new Date().toISOString() },
+    ];
+    const p = P.computeProgress(noise, TODAY);
+    assert(p.xp === 0 && p.sessions === 0, `got xp=${p.xp} sessions=${p.sessions}`);
+    return 'noise excluded';
+  });
+
+  await test('Empty history is safe (level 1, no NaN)', async () => {
+    const p = P.computeProgress([], TODAY);
+    assert(p.level === 1 && p.xp === 0 && p.dailyStreak === 0 && p.accuracy === 0,
+      JSON.stringify(p));
+    assert(Object.values(p).every(v => typeof v !== 'number' || Number.isFinite(v)), 'NaN leaked');
+    return 'level 1, all finite';
+  });
+
+  await test('Badges derive from history and are retroactive', async () => {
+    const p = P.computeProgress([mkA(0), mkA(-1), mkA(-2)], TODAY);
+    const b = P.computeBadges(p, [mkA(0), mkA(-1), mkA(-2)]);
+    assert(Array.isArray(b) && b.length >= 8, `expected the full rule set, got ${b.length}`);
+    const byId = Object.fromEntries(b.map(x => [x.id, x.earned]));
+    assert(byId['first-steps'] === true, 'First Steps should be earned after a session');
+    assert(byId['perfect-set'] === true, 'three perfect 5/5 sets should earn Perfect Set');
+    assert(byId['streak-3']    === true, '3-day streak should be earned');
+    assert(byId['streak-10']   === false, '10-day streak should not be earned');
+    return `${b.length} rules, ${b.filter(x => x.earned).length} earned`;
+  });
+
+  await test("Engine runs against Jaden's real history and returns sane values", async () => {
+    const res = await db('attempts?student=eq.Jaden&select=*&order=created_at.desc&limit=500');
+    assert(res.ok, `HTTP ${res.status}`);
+    const rows = await res.json();
+    const p = P.computeProgress(rows);
+    assert(p.level >= 1, 'level must be at least 1');
+    assert(p.xp >= 0, 'xp must not be negative');
+    assert(p.accuracy >= 0 && p.accuracy <= 100, `accuracy out of range: ${p.accuracy}`);
+    assert(p.xpIntoLevel >= 0 && p.xpIntoLevel < p.xpForNextLevel,
+      `xpIntoLevel ${p.xpIntoLevel} outside level span ${p.xpForNextLevel}`);
+    assert(p.correct <= p.questions, 'correct exceeds questions answered');
+    assert(p.dailyStreak <= p.bestDailyStreak, 'current streak exceeds best');
+    return `L${p.level}, ${p.xp} XP, ${p.accuracy}% over ${p.questions} questions`;
+  });
+
   // ── 12. App Logic — data loading ─────────────────────────────────────────
   suite('🧠 App Logic — data loading (iframe)');
 


### PR DESCRIPTION
Closes #18

The engine behind the home screen, level map and badge case. Pure functions, no DOM, no network — tests call them directly.

## Derived, not stored
No new tables or columns. XP, levels, streaks and badges are all computed from the existing `attempts` history. Two reasons: **Jaden's past work counts the moment this ships** rather than resetting him to zero, and there is no second source of truth to drift out of sync.

## Rules
- **XP** — 15 per correct answer, +25 for a perfect set of 5 or more. A clean set is worth more than the sum of its parts, but only if it was a real set.
- **Levels** — ramp of +50/level to level 10, then +25/level.
- **Daily streak** — consecutive local calendar days with a completed session.
- **Badges** — 10 rules as pure predicates, retroactive over history.

## Two judgement calls worth flagging

**The level ramp has a knee at 10.** Running against real data, Jaden is already **level 20 on 9,485 XP** (35 sessions, 754 questions, 83% accuracy). With a straight +50/level ramp his next level would have cost 1,000 XP — about 67 correct answers — which stalls progression right where he actually is. Halving the slope past level 10 brings that to 640 XP (~43 answers).

I chose not to deflate the level number itself. He did the work; the number should say so.

**This means the level map (#20) needs a rolling window**, not a fixed 1–20 board — he would open it already at the end. A fixed board was never going to survive four years of content anyway, so I will build it as a window around the current level.

**A streak may end today *or* yesterday.** Counting only from today would break every streak each morning before the first session of the day.

## Tests — 12 new, 136 total
Curve round-trip across 10 levels and monotonicity across 40; XP rules including both bonus boundaries; all four streak cases (ends today / ends yesterday / broken by a gap / two sessions one day); local-day boundaries at 23:45 and 00:15; exclusion of incomplete and zero-question rows; empty history returns level 1 with no NaN; badge derivation; and a sanity pass over real data asserting invariants like `xpIntoLevel < xpForNextLevel` and `dailyStreak <= bestDailyStreak`.

**136/136 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)