### PR TITLE
Home screen, level map and badge case (reward surface)

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,6 +284,141 @@
       width: 100%; max-width: 760px;
     }
 
+
+    /* ══════════════════════════════════════════════════════════════════
+       HOME - the reward surface
+
+       Deliberately the only dark screen in the app. Problem screens serve
+       focus; this one serves motivation. Walking from a bright working
+       surface into a dark celebratory one is itself the reward, and it
+       costs one token swap rather than a second design system.
+       ══════════════════════════════════════════════════════════════════ */
+    #home-screen.card {
+      background: var(--bg);
+      border-color: var(--line);
+      box-shadow: var(--sh-3);
+      padding: 0; overflow: hidden;
+    }
+    .home-hero {
+      padding: 24px 24px 22px;
+      background:
+        radial-gradient(ellipse 70% 120% at 88% -10%, rgba(56,189,248,.13), transparent 62%),
+        radial-gradient(ellipse 60% 130% at 8% 110%, rgba(240,180,41,.10), transparent 60%);
+      border-bottom: 1px solid var(--line);
+    }
+    .home-top { display:flex; align-items:flex-start; gap:14px; flex-wrap:wrap; }
+    .home-greet { flex:1; min-width:190px; }
+    .home-greet h2 {
+      font-family: var(--f-rwd); font-weight:800; letter-spacing:-.02em;
+      font-size:1.5rem; color:var(--tx); margin-bottom:4px;
+    }
+    .home-greet p { font-size:.9rem; color:var(--tx-2); line-height:1.5; }
+    .home-streak {
+      display:flex; align-items:center; gap:9px; flex:none;
+      padding:9px 15px; border-radius:var(--r2);
+      background:var(--streak-soft);
+      border:1px solid color-mix(in srgb, var(--streak) 42%, transparent);
+      color:var(--streak);
+    }
+    .home-streak .ico { width:22px; height:22px; }
+    .home-streak-n {
+      font-family:var(--f-rwd); font-weight:800; font-size:1.35rem; line-height:1;
+      font-variant-numeric:tabular-nums;
+    }
+    .home-streak-l {
+      font-size:.6rem; text-transform:uppercase; letter-spacing:.09em;
+      font-weight:700; color:var(--tx-2); margin-top:3px;
+    }
+    .home-xp { margin-top:18px; }
+    .home-xp-top { display:flex; justify-content:space-between; align-items:baseline; gap:10px; margin-bottom:6px; }
+    .home-lvl {
+      font-family:var(--f-rwd); font-weight:800; font-size:.86rem;
+      background:var(--acc); color:var(--acc-on);
+      padding:4px 11px; border-radius:99px; letter-spacing:-.01em;
+    }
+    .home-xp-num {
+      font-family:var(--f-num); font-size:.78rem; color:var(--tx-2);
+      font-variant-numeric:tabular-nums;
+    }
+    .home-xp-track { height:9px; border-radius:99px; background:var(--surface-2); overflow:hidden; }
+    .home-xp-fill {
+      height:100%; border-radius:99px;
+      background:linear-gradient(90deg, var(--acc), color-mix(in srgb, var(--acc) 55%, #fff));
+      width:0; transition:width .9s cubic-bezier(.22,1,.36,1);
+    }
+
+    .home-body { padding:20px 24px 24px; display:flex; flex-direction:column; gap:22px; }
+    .home-sec-title {
+      font-family:var(--f-rwd); font-weight:800; font-size:.78rem;
+      text-transform:uppercase; letter-spacing:.11em; color:var(--tx-3);
+      margin-bottom:13px; display:flex; align-items:center; gap:9px;
+    }
+    .home-sec-title span:last-child {
+      margin-left:auto; font-family:var(--f-body); font-weight:600;
+      text-transform:none; letter-spacing:0; color:var(--tx-3); font-size:.72rem;
+    }
+
+    /* ── Level map: a rolling window, not a fixed board ── */
+    .lvl-map { display:flex; align-items:center; gap:5px; overflow-x:auto; padding-bottom:4px; }
+    .lvl-node {
+      width:46px; height:46px; flex:none; border-radius:50%;
+      display:flex; align-items:center; justify-content:center;
+      font-family:var(--f-rwd); font-weight:800; font-size:.86rem;
+      font-variant-numeric:tabular-nums; position:relative;
+      background:var(--surface-2); color:var(--tx-3);
+      border:2px solid var(--line);
+    }
+    .lvl-node .ico { width:19px; height:19px; }
+    .lvl-node.done {
+      background:var(--acc); color:var(--acc-on); border-color:var(--acc);
+      box-shadow:0 0 0 3px var(--acc-soft);
+    }
+    .lvl-node.now {
+      background:var(--acc); color:var(--acc-on); border-color:var(--acc);
+      box-shadow:0 0 0 3px var(--acc), 0 0 22px -3px var(--acc);
+    }
+    .lvl-node.now::after {
+      content:''; position:absolute; left:50%; top:-11px; transform:translateX(-50%);
+      border:5px solid transparent; border-top-color:var(--acc);
+    }
+    .lvl-link { flex:1; min-width:10px; height:3px; border-radius:99px; background:var(--line); }
+    .lvl-link.done { background:var(--acc); }
+
+    /* ── Badge case ── */
+    .badge-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(74px,1fr)); gap:14px; }
+    .badge-item { display:flex; flex-direction:column; align-items:center; gap:6px; text-align:center; }
+    .badge-ring {
+      width:46px; height:46px; border-radius:50%;
+      display:flex; align-items:center; justify-content:center;
+      background:var(--acc-soft); color:var(--acc);
+      border:2px solid color-mix(in srgb, var(--acc) 58%, transparent);
+    }
+    .badge-ring .ico { width:21px; height:21px; }
+    .badge-item.locked .badge-ring {
+      background:var(--surface-2); color:var(--tx-3);
+      border-color:var(--line); opacity:.5;
+    }
+    .badge-name { font-size:.63rem; font-weight:600; color:var(--tx-2); line-height:1.35; }
+    .badge-item.locked .badge-name { color:var(--tx-3); opacity:.75; }
+
+    /* ── Stats ── */
+    .home-stats { display:grid; grid-template-columns:repeat(2,1fr); gap:11px; }
+    @media (min-width:620px) { .home-stats { grid-template-columns:repeat(4,1fr); } }
+    .home-stat {
+      background:var(--surface); border:1px solid var(--line);
+      border-radius:var(--r1); padding:12px 13px;
+    }
+    .home-stat-l {
+      font-size:.6rem; font-weight:700; letter-spacing:.1em; text-transform:uppercase;
+      color:var(--tx-3); margin-bottom:6px;
+    }
+    .home-stat-v {
+      font-family:var(--f-rwd); font-weight:800; font-size:1.3rem; line-height:1;
+      color:var(--tx); font-variant-numeric:tabular-nums;
+    }
+    .home-cta { display:flex; gap:10px; flex-wrap:wrap; align-items:center; margin-top:2px; }
+    .home-cta .btn-primary { background:var(--acc); color:var(--acc-on); }
+
     /* ── START SCREEN ── */
     #start-screen { text-align: center; }
     .subject-icon { font-size: 64px; animation: float 2s ease-in-out infinite alternate; display: block; margin-bottom: 10px; }
@@ -1170,6 +1305,9 @@
   <symbol id="ic-clock" viewBox="0 0 24 24">
     <circle cx="12" cy="12" r="8.5"/><path d="M12 7.2V12l3.1 1.9"/>
   </symbol>
+  <symbol id="ic-check" viewBox="0 0 24 24">
+    <path d="M5 12.5l4.6 4.6L19 7.6"/>
+  </symbol>
   <symbol id="ic-trophy" viewBox="0 0 24 24">
     <path d="M7.5 4h9v5.2a4.5 4.5 0 0 1-9 0z"/>
     <path d="M7.5 5.6H5.2a2.7 2.7 0 0 0 2.6 3.5M16.5 5.6h2.3a2.7 2.7 0 0 1-2.6 3.5"/>
@@ -1183,6 +1321,7 @@
 
 <!-- ══ SECTION NAV ══ -->
 <nav id="section-nav">
+  <button class="section-btn" id="sec-btn-home" onclick="switchSection('home')"><svg class="ico" aria-hidden="true"><use href="#ic-star"></use></svg>Home</button>
   <button class="section-btn active" id="sec-btn-grades" onclick="switchSection('grades')"><svg class="ico" aria-hidden="true"><use href="#ic-grades"></use></svg>Grades</button>
   <button class="section-btn"        id="sec-btn-tests"  onclick="switchSection('tests')"><svg class="ico" aria-hidden="true"><use href="#ic-tests"></use></svg>Standardized Tests</button>
 </nav>
@@ -1310,6 +1449,56 @@
         <div class="grade-badge">4</div>
         <div class="grade-card-label">4th Grade</div>
         <div class="grade-card-sub">Week 1 packet loaded</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- HOME SCREEN — the reward surface -->
+  <div id="home-screen" class="card surface-reward hidden">
+    <div class="home-hero">
+      <div class="home-top">
+        <div class="home-greet">
+          <h2 id="home-greeting">Welcome back</h2>
+          <p id="home-sub">Loading your progress…</p>
+        </div>
+        <div class="home-streak" id="home-streak-box">
+          <svg class="ico" aria-hidden="true"><use href="#ic-flame"></use></svg>
+          <div>
+            <div class="home-streak-n" id="home-streak-n">0</div>
+            <div class="home-streak-l">day streak</div>
+          </div>
+        </div>
+      </div>
+      <div class="home-xp">
+        <div class="home-xp-top">
+          <span class="home-lvl" id="home-level">Level 1</span>
+          <span class="home-xp-num" id="home-xp-num">0 / 100 XP</span>
+        </div>
+        <div class="home-xp-track"><div class="home-xp-fill" id="home-xp-fill"></div></div>
+      </div>
+    </div>
+
+    <div class="home-body">
+      <div class="home-cta">
+        <button class="btn btn-primary" onclick="switchSection('tests')">
+          <svg class="ico" aria-hidden="true"><use href="#ic-shuffle"></use></svg>Keep practising
+        </button>
+        <button class="link-btn" onclick="switchSection('grades')">Change grade</button>
+      </div>
+
+      <div>
+        <div class="home-sec-title"><span>Levels</span><span id="home-map-note"></span></div>
+        <div class="lvl-map" id="home-lvl-map"></div>
+      </div>
+
+      <div>
+        <div class="home-sec-title"><span>Badges</span><span id="home-badge-note"></span></div>
+        <div class="badge-grid" id="home-badges"></div>
+      </div>
+
+      <div>
+        <div class="home-sec-title"><span>All time</span></div>
+        <div class="home-stats" id="home-stats"></div>
       </div>
     </div>
   </div>
@@ -1884,14 +2073,159 @@ function setTestsMode(mode) {
   if (mode === 'practice') updateWeakButton();
 }
 
+// ═══════════════════════════════════════════════════════════════════
+//  HOME SCREEN RENDER
+// ═══════════════════════════════════════════════════════════════════
+
+let _homeAttempts = null;         // cached per session; the history rarely moves
+let _homeAttemptsInFlight = null; // shared promise so concurrent renders cannot race
+
+async function _fetchProgressAttempts(force) {
+  if (_homeAttempts && !force) return _homeAttempts;
+  // Two renders can fire together (selectGrade -> switchSection -> renderHome).
+  // Share the in-flight request rather than letting the slower one clobber.
+  if (_homeAttemptsInFlight && !force) return _homeAttemptsInFlight;
+
+  _homeAttemptsInFlight = (async () => {
+    try {
+      const res = await fetch(
+        `${SUPABASE_URL}/rest/v1/attempts?student=eq.Jaden&select=*&order=created_at.desc&limit=500`,
+        { headers: { apikey: SUPABASE_ANON, Authorization: `Bearer ${SUPABASE_ANON}` } });
+      if (!res.ok) return _homeAttempts || [];
+      // Only a successful fetch is allowed to populate the cache. Caching []
+      // would poison it permanently: an empty array is truthy, so every later
+      // call would short-circuit and the home screen would show zeros forever.
+      _homeAttempts = await res.json();
+      return _homeAttempts;
+    } catch (e) {
+      return _homeAttempts || [];
+    } finally {
+      _homeAttemptsInFlight = null;
+    }
+  })();
+  return _homeAttemptsInFlight;
+}
+
+function _greetingFor(d = new Date()) {
+  const h = d.getHours();
+  if (h < 12) return 'Good morning';
+  if (h < 17) return 'Good afternoon';
+  return 'Good evening';
+}
+
+// The map is a WINDOW around the current level, not a fixed board. A fixed
+// 1-20 board would already be complete (real history puts Jaden at ~20) and
+// would not survive years of content. Two cleared levels behind for a sense
+// of travel, the current one, three ahead to aim at.
+function _levelWindow(level, back = 2, ahead = 3) {
+  const from = Math.max(1, level - back);
+  const out = [];
+  for (let l = from; l <= level + ahead; l++) out.push(l);
+  return out;
+}
+
+function renderLevelMap(progress) {
+  const el = document.getElementById('home-lvl-map');
+  if (!el) return;
+  const levels = _levelWindow(progress.level);
+  const parts = [];
+  levels.forEach((l, i) => {
+    const state = l < progress.level ? 'done' : l === progress.level ? 'now' : '';
+    const inner = l < progress.level
+      ? '<svg class="ico" aria-hidden="true"><use href="#ic-check"></use></svg>'
+      : String(l);
+    parts.push(`<div class="lvl-node ${state}" title="Level ${l}">${inner}</div>`);
+    if (i < levels.length - 1) {
+      parts.push(`<i class="lvl-link ${l < progress.level ? 'done' : ''}"></i>`);
+    }
+  });
+  el.innerHTML = parts.join('');
+  const note = document.getElementById('home-map-note');
+  if (note) note.textContent = `${progress.xpToNextLevel} XP to level ${progress.level + 1}`;
+}
+
+function renderBadges(progress, attempts) {
+  const el = document.getElementById('home-badges');
+  if (!el) return;
+  const badges = computeBadges(progress, attempts);
+  el.innerHTML = badges.map(b => `
+    <div class="badge-item ${b.earned ? '' : 'locked'}" title="${b.name}">
+      <div class="badge-ring"><svg class="ico" aria-hidden="true"><use href="#${b.ico}"></use></svg></div>
+      <span class="badge-name">${b.name}</span>
+    </div>`).join('');
+  const note = document.getElementById('home-badge-note');
+  if (note) note.textContent = `${badges.filter(b => b.earned).length} of ${badges.length} earned`;
+}
+
+function renderHomeStats(p) {
+  const el = document.getElementById('home-stats');
+  if (!el) return;
+  const stats = [
+    ['Questions',  p.questions],
+    ['Accuracy',   p.accuracy + '%'],
+    ['Sessions',   p.sessions],
+    ['Best streak', p.bestDailyStreak + (p.bestDailyStreak === 1 ? ' day' : ' days')],
+  ];
+  el.innerHTML = stats.map(([l, v]) =>
+    `<div class="home-stat"><div class="home-stat-l">${l}</div><div class="home-stat-v">${v}</div></div>`).join('');
+}
+
+async function renderHome(force) {
+  const attempts = await _fetchProgressAttempts(force);
+  const p = computeProgress(attempts);
+
+  document.getElementById('home-greeting').textContent = `${_greetingFor()}, Jaden`;
+
+  const sub = document.getElementById('home-sub');
+  sub.textContent = p.sessions === 0
+    ? 'Pick a topic and answer your first question to start earning XP.'
+    : p.todayDone
+      ? `You have already practised today. ${p.xpToNextLevel} XP to level ${p.level + 1}.`
+      : p.dailyStreak > 0
+        ? `Practise today to keep your ${p.dailyStreak}-day streak alive.`
+        : 'Answer a few questions today to start a new streak.';
+
+  document.getElementById('home-streak-n').textContent = p.dailyStreak;
+  const box = document.getElementById('home-streak-box');
+  // A cold streak should not wear the live streak colour.
+  box.style.opacity = p.dailyStreak > 0 ? '' : '.55';
+
+  document.getElementById('home-level').textContent  = `Level ${p.level}`;
+  document.getElementById('home-xp-num').textContent = `${p.xpIntoLevel} / ${p.xpForNextLevel} XP`;
+
+  // Ease the bar to its value rather than snapping - the motion is what makes
+  // progress feel earned. Only the first paint runs from zero; later renders
+  // just set the value and let the CSS transition tween from wherever it is.
+  //
+  // Uses a timer, not requestAnimationFrame: rAF is suspended in a background
+  // tab, which would strand the bar at 0% and misreport real progress. The
+  // animation is decoration, the final width is not.
+  const fill = document.getElementById('home-xp-fill');
+  const target = p.levelPct + '%';
+  if (!fill.dataset.painted) {
+    fill.dataset.painted = '1';
+    fill.style.width = '0%';
+    setTimeout(() => { fill.style.width = target; }, 40);
+  } else {
+    fill.style.width = target;
+  }
+
+  renderLevelMap(p);
+  renderBadges(p, attempts);
+  renderHomeStats(p);
+}
+
 function switchSection(sec) {
   activeSection = sec;
-  ['grades','tests'].forEach(s =>
+  ['home','grades','tests'].forEach(s =>
     document.getElementById(`sec-btn-${s}`)?.classList.toggle('active', s === sec));
   // Subject toggle only shown for tests-practice (domain nav handles subject there)
   document.getElementById('subject-toggle').style.display = 'none';
   if (sec === 'grades') {
     show('grades-screen');
+  } else if (sec === 'home') {
+    show('home-screen');
+    renderHome();
   } else {
     show('test-config-screen');
     setTestsMode(testsMode); // restore last sub-mode
@@ -1943,11 +2277,13 @@ async function selectGrade(grade) {
   // Re-render domain nav with freshly loaded counts, then drop into practice
   buildNav();
   updateWeakButton();
-  switchSection('tests');
+  // Land on Home rather than straight into config: the reward surface is
+  // the point of arrival, and the CTA there leads into practice.
+  switchSection('home');
 }
 
 function show(id) {
-  ['start-screen','grades-screen','reading-screen','question-screen','end-screen',
+  ['start-screen','grades-screen','home-screen','reading-screen','question-screen','end-screen',
    'test-config-screen','test-results-screen','history-screen',
    'test-review-screen'].forEach(s=>
     document.getElementById(s).classList.toggle('hidden', s!==id));


### PR DESCRIPTION
Closes #19
Closes #20
Closes #21

These three share one screen, so splitting them would have shipped a half-built home. Landing after grade selection is now Home, with the CTA leading into practice.

## The two-surface payoff
This is the app's **only dark screen**. Problem screens serve focus; this one serves motivation. Because `.surface-reward` redefines the same token names rather than adding dark variants, every component reskins itself — the whole screen cost a token swap, not a second design system.

## The level map is a rolling window
Two cleared levels behind, the current one, three ahead. Not a fixed 1–20 board: real history puts Jaden at **level 20**, so a fixed board would open already complete — and it would not have survived four years of content regardless.

## Three bugs found while building

**1. Silent name collision.** An existing `_fetchAttempts()` (`limit=50`, parent dashboard) **overwrote** my new one — function declarations hoist and the later wins. The home screen was reading 50 rows instead of 96 and confidently reporting **Level 13 / 359 questions instead of Level 20 / 754**. No error, just wrong numbers. Renamed to `_fetchProgressAttempts`.

This is the one worth noting: it produced plausible-looking output, and I only caught it because the figure disagreed with an earlier measurement.

**2. Cache poisoning.** `_homeAttempts = []` is **truthy**, so caching an empty array after a failed fetch would short-circuit every later call and strand the home screen at zeros permanently. Only a successful fetch populates the cache now.

**3. Render race.** `selectGrade → switchSection → renderHome` can fire concurrently; in-flight requests are now deduped through one shared promise.

## One robustness call
The XP bar animates with a timer, **not `requestAnimationFrame`** — rAF is suspended in a background tab, which stranded the bar at 0% while real progress went unreported. The animation is decoration; the final width is not, so it must not depend on the tab being visible.

## Verified against real data
Level 20 · 9,485 XP · 754 questions · 83% accuracy · 35 sessions · 8 of 10 badges earned · map reads "640 XP to level 21". Concurrent `renderHome()` calls produce a consistent result.

**136/136 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)