### PR TITLE
Micro-interactions and the level-up moment

### DIFF
--- a/index.html
+++ b/index.html
@@ -419,6 +419,104 @@
     .home-cta { display:flex; gap:10px; flex-wrap:wrap; align-items:center; margin-top:2px; }
     .home-cta .btn-primary { background:var(--acc); color:var(--acc-on); }
 
+
+    /* ══════════════════════════════════════════════════════════════════
+       MOTION
+
+       Dew's palette will not do the gamification work on its own the way a
+       dark screen with a glowing objective does for free. Without motion
+       this drifts into "nice worksheet" - the stated failure mode. So the
+       moments that matter get real weight, and everything else stays still.
+
+       Every animation degrades to an instant state change under
+       prefers-reduced-motion; none of them carry information on their own.
+       ══════════════════════════════════════════════════════════════════ */
+
+    /* A correct answer gets a short settle - felt, not watched. */
+    @keyframes optSettle {
+      0%   { transform: translateY(0)     scale(1);     }
+      35%  { transform: translateY(-3px)  scale(1.015); }
+      100% { transform: translateY(0)     scale(1);     }
+    }
+    .option.correct { animation: optSettle .34s cubic-bezier(.34,1.4,.5,1) both; }
+
+    /* A wrong answer is firm, not punitive: one short nudge, no shaking. */
+    @keyframes optNudge {
+      0%,100% { transform: translateX(0);    }
+      30%     { transform: translateX(-3px); }
+      65%     { transform: translateX(2px);  }
+    }
+    .option.wrong { animation: optNudge .26s ease-out both; }
+
+    /* Level nodes fill and settle when a level clears. */
+    @keyframes nodeClear {
+      0%   { transform: scale(1);    }
+      45%  { transform: scale(1.14); }
+      100% { transform: scale(1);    }
+    }
+    .lvl-node.just-cleared { animation: nodeClear .5s cubic-bezier(.34,1.5,.5,1) both; }
+
+    /* ── Level-up: a moment, not a toast ── */
+    .levelup {
+      position: fixed; inset: 0; z-index: 900;
+      display: none; align-items: center; justify-content: center;
+      background: rgba(10,15,28,.62);
+      backdrop-filter: blur(3px); -webkit-backdrop-filter: blur(3px);
+      padding: 20px;
+    }
+    .levelup.show { display: flex; animation: luFade .3s ease both; }
+    @keyframes luFade { from { opacity: 0; } }
+    .levelup-card {
+      background: #0a0f1c; color: #e8eefc;
+      border: 1px solid rgba(240,180,41,.45);
+      border-radius: 26px; padding: 34px 40px; text-align: center;
+      box-shadow: 0 30px 80px -20px rgba(0,0,0,.85), 0 0 70px -18px rgba(240,180,41,.4);
+      animation: luRise .5s cubic-bezier(.22,1.2,.4,1) both;
+      max-width: 340px;
+    }
+    @keyframes luRise { from { opacity:0; transform: translateY(16px) scale(.94); } }
+    .levelup-eyebrow {
+      font-family:'Source Sans 3',sans-serif; font-size:.68rem; font-weight:700;
+      letter-spacing:.16em; text-transform:uppercase; color:#8ea0c4; margin-bottom:10px;
+    }
+    .levelup-n {
+      font-family:'Syne',sans-serif; font-weight:800; font-size:3.6rem; line-height:1;
+      color:#f0b429; letter-spacing:-.03em; font-variant-numeric:tabular-nums;
+      animation: luPop .55s cubic-bezier(.3,1.6,.5,1) .12s both;
+    }
+    @keyframes luPop { from { opacity:0; transform: scale(.5); } }
+    .levelup-l { font-family:'Syne',sans-serif; font-weight:800; font-size:1.05rem; margin-top:6px; }
+    .levelup-sub { font-size:.86rem; color:#8ea0c4; margin-top:10px; line-height:1.5; }
+    .levelup-btn {
+      margin-top:20px; background:#f0b429; color:#0a0f1c; border:none;
+      font-family:'Syne',sans-serif; font-weight:800; font-size:.95rem;
+      padding:11px 26px; border-radius:50px; cursor:pointer;
+    }
+    .levelup-btn:hover { filter:brightness(1.07); }
+    .levelup-btn:focus-visible { outline:2px solid #fff; outline-offset:3px; }
+
+    /* XP earned readout on the results screen */
+    .xp-earned {
+      display:inline-flex; align-items:center; gap:7px;
+      font-family:var(--f-num); font-weight:600; font-size:.92rem;
+      color:var(--acc); background:var(--acc-soft);
+      border:1px solid var(--acc-line); border-radius:50px;
+      padding:6px 15px; margin-top:10px;
+      animation: xpIn .45s cubic-bezier(.22,1.3,.4,1) .15s both;
+    }
+    @keyframes xpIn { from { opacity:0; transform:translateY(7px) scale(.92); } }
+    .xp-earned .ico { width:16px; height:16px; }
+
+    /* ══ Reduced motion: every animation becomes an instant state change ══ */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: .001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: .001ms !important;
+        scroll-behavior: auto !important;
+      }
+    }
+
     /* ── START SCREEN ── */
     #start-screen { text-align: center; }
     .subject-icon { font-size: 64px; animation: float 2s ease-in-out infinite alternate; display: block; margin-bottom: 10px; }
@@ -1424,6 +1522,7 @@
     <h2 id="end-title">Session Complete!</h2>
     <div class="stars-row" id="stars-row"></div>
     <div class="final-score" id="final-score"></div>
+    <div id="xp-earned-slot"></div>
     <div class="stats-row">
       <div class="stat-box"><div class="stat-num" id="stat-pct"></div><div class="stat-label">Accuracy</div></div>
       <div class="stat-box"><div class="stat-num" id="stat-streak"></div><div class="stat-label">Best Streak</div></div>
@@ -1796,6 +1895,17 @@
 </div>
 
 <div class="streak-popup" id="streak-popup"></div>
+
+<!-- Level-up: shown once, after a session that crossed a level boundary -->
+<div class="levelup" id="levelup" role="dialog" aria-modal="true" aria-labelledby="levelup-l">
+  <div class="levelup-card">
+    <div class="levelup-eyebrow">Level up</div>
+    <div class="levelup-n" id="levelup-n">2</div>
+    <div class="levelup-l" id="levelup-l">Nice work, Jaden</div>
+    <div class="levelup-sub" id="levelup-sub"></div>
+    <button class="levelup-btn" onclick="closeLevelUp()">Keep going</button>
+  </div>
+</div>
 
 <div id="loading-overlay" style="position:fixed;inset:0;z-index:10000;background:#0a0e2a;display:flex;align-items:center;justify-content:center;flex-direction:column;gap:20px;">
   <div style="font-size:2.5rem;">📚</div>
@@ -2627,6 +2737,51 @@ function nextQuestion() {
   } else renderQuestion();
 }
 
+// ═══════════════════════════════════════════════════════════════════
+//  LEVEL-UP MOMENT
+//
+//  Dew is calm by design, so the reward has to come from motion rather
+//  than from the palette. Crossing a level boundary is the one point in
+//  a session that earns a full-screen beat.
+// ═══════════════════════════════════════════════════════════════════
+
+function closeLevelUp() {
+  document.getElementById('levelup')?.classList.remove('show');
+}
+document.addEventListener('keydown', e => {
+  if (e.key === 'Escape') closeLevelUp();
+});
+
+function showLevelUp(newLevel, xpGained) {
+  const el = document.getElementById('levelup');
+  if (!el) return;
+  document.getElementById('levelup-n').textContent = newLevel;
+  document.getElementById('levelup-l').textContent = `Level ${newLevel}`;
+  document.getElementById('levelup-sub').textContent =
+    `You earned ${xpGained} XP this session.`;
+  el.classList.add('show');
+}
+
+// Compares progress before and after the session's attempt lands, and
+// paints the XP readout. Awaited nowhere - a celebration must never
+// block the results screen from appearing.
+async function _afterSessionProgress(xpGainedGuess) {
+  try {
+    const before = computeProgress(await _fetchProgressAttempts());
+    const after  = computeProgress(await _fetchProgressAttempts(true));
+
+    const gained = Math.max(0, after.xp - before.xp) || xpGainedGuess || 0;
+    const host = document.getElementById('xp-earned-slot');
+    if (host && gained > 0) {
+      host.innerHTML =
+        `<span class="xp-earned"><svg class="ico" aria-hidden="true"><use href="#ic-star"></use></svg>+${gained} XP</span>`;
+    }
+    if (after.level > before.level) {
+      setTimeout(() => showLevelUp(after.level, gained), 700);
+    }
+  } catch (e) { /* never let a celebration break the results screen */ }
+}
+
 function showEndScreen() {
   document.getElementById('progress-bar').style.width='100%';
   const total=questions.length, pct=score/total;
@@ -2669,11 +2824,15 @@ function showEndScreen() {
   // Show Review button if there were any answered questions
   const reviewBtn = document.getElementById('practice-review-btn');
   if (reviewBtn) reviewBtn.classList.toggle('hidden', practiceAnswers.length === 0);
+
+  // Fire-and-forget: the results screen must render regardless.
+  document.getElementById('xp-earned-slot').innerHTML = '';
+  _afterSessionProgress(score * 15 + (score === total && total >= 5 ? 25 : 0));
 }
 
 function launchConfetti() { for(let i=0;i<16;i++) setTimeout(launchConfettiPiece,i*35); }
 function launchConfettiPiece() {
-  const cols=['#e94560','#ffd700','#27ae60','#3498db','#9b59b6','#f39c12'];
+  const cols=['#2f6b4f','#7ba889','#d98324','#f0b429','#1a8043','#b3cbac'];
   const el=document.createElement('div');
   el.className='confetti-piece';
   el.style.cssText=`left:${Math.random()*100}%;background:${cols[Math.floor(Math.random()*cols.length)]};animation-duration:${.8+Math.random()*1.2}s;transform:rotate(${Math.random()*360}deg)`;


### PR DESCRIPTION
Closes #24

I flagged this in the design review as the make-or-break item: **Dew's palette will not do the gamification work on its own** the way a dark screen with a glowing objective does for free. Without motion, the app drifts into "nice worksheet" — the exact failure mode you ruled out.

## What got motion
- **Level-up is a moment, not a toast.** Full-screen beat, gold on dark, blurred backdrop. It is the one point in a session that earns one.
- **Correct answers settle** — a short lift, felt rather than watched.
- **Wrong answers get one short nudge**, not a shake. Firm, not punitive.
- **Level nodes scale when cleared.**
- **XP earned** appears under the score on the results screen.
- **Confetti** now draws from the palette instead of the old brand colours.

## Safety around the celebration
`_afterSessionProgress()` is **fired without being awaited** and fully wrapped, so a celebration can never block or break the results screen. The screen renders regardless of whether the progress refetch succeeds.

## Reduced motion
Every animation degrades to an instant state change under `prefers-reduced-motion`, and **none of them carry information on their own** — the XP figure, the level number and the correct/incorrect states are all readable with motion fully disabled. Verified the media rule is present and correctly formed in the parsed stylesheet, not just present in source.

## Verified in-browser
Level-up overlay renders with the right level and XP; a real 3-question session produces a `+45 XP` readout in the right place; Esc closes the overlay.

**136/136 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)