### PR TITLE
Separate regular classwork from standardized test prep

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,12 +182,32 @@
     /* Long labels wrap to two lines on a phone and make the bar ungainly.
        Swap in a short form rather than letting it reflow. */
     .nav-short { display: none; }
-    @media (max-width: 560px) {
+    @media (max-width: 620px) {
       .nav-full  { display: none; }
       .nav-short { display: inline; }
-      .section-btn { padding: 7px 14px; font-size: .84rem; }
+      .section-btn { padding: 7px 11px; font-size: .8rem; gap: 5px; }
+      .section-btn .ico { width: 1em; height: 1em; }
       #section-nav { gap: 2px; }
     }
+    /* Four sections cannot fit a phone at full width. Below 470px only the
+       active tab keeps its label; the rest go icon-only, which guarantees the
+       bar fits rather than pushing the last tab off the edge where nobody
+       finds it. Horizontal scroll stays as a safety net. */
+    @media (max-width: 470px) {
+      .section-btn .sec-label { display: none; }
+      .section-btn.active .sec-label { display: inline; }
+      .section-btn { padding: 8px 12px; }
+      .section-btn.active { padding: 8px 14px; }
+    }
+    #section-nav {
+      max-width: 100%;
+      overflow-x: auto;
+      scrollbar-width: none;
+      -ms-overflow-style: none;
+      scroll-snap-type: x proximity;
+    }
+    #section-nav::-webkit-scrollbar { display: none; }
+    .section-btn { flex: none; scroll-snap-align: center; }
 
     /* ── SUBJECT TOGGLE ── */
     #subject-toggle {
@@ -526,6 +546,37 @@
         scroll-behavior: auto !important;
       }
     }
+
+    /* ── CLASSWORK ── */
+    .cw-empty {
+      text-align:center; padding:30px 20px; color:var(--tx-2);
+      background:var(--surface-2); border:1px dashed var(--line-strong);
+      border-radius:var(--r2); line-height:1.65; font-size:.9rem;
+    }
+    .cw-empty strong { color:var(--tx); display:block; margin-bottom:6px; font-size:.98rem; }
+    .cw-list { display:flex; flex-direction:column; gap:10px; }
+    .cw-item {
+      display:flex; align-items:center; gap:14px; width:100%; text-align:left;
+      background:var(--surface); border:1.5px solid var(--line);
+      border-radius:var(--r2); padding:14px 16px; cursor:pointer;
+      font-family:var(--f-body); color:var(--tx);
+      transition:border-color .16s, background .16s, transform .12s;
+    }
+    .cw-item:hover { border-color:var(--acc); background:var(--acc-soft); transform:translateY(-1px); }
+    .cw-item:focus-visible { outline:2px solid var(--acc); outline-offset:2px; }
+    .cw-item-ico {
+      width:38px; height:38px; flex:none; border-radius:var(--r1);
+      display:flex; align-items:center; justify-content:center;
+      background:var(--acc-soft); color:var(--acc);
+    }
+    .cw-item-ico .ico { width:19px; height:19px; }
+    .cw-item-body { flex:1; min-width:0; display:block; }
+    /* These are spans inside a flex row - they must be block or the name and
+       the count render on one line, running together. */
+    .cw-item-name { display:block; font-weight:600; font-size:.98rem; margin-bottom:3px; }
+    .cw-item-meta { display:block; font-size:.76rem; color:var(--tx-3); font-family:var(--f-num); font-variant-numeric:tabular-nums; }
+    .cw-item-go { color:var(--tx-3); flex:none; }
+    .cw-item:hover .cw-item-go { color:var(--acc); }
 
     /* ── START SCREEN ── */
     #start-screen { text-align: center; }
@@ -1416,6 +1467,13 @@
   <symbol id="ic-clock" viewBox="0 0 24 24">
     <circle cx="12" cy="12" r="8.5"/><path d="M12 7.2V12l3.1 1.9"/>
   </symbol>
+  <symbol id="ic-classwork" viewBox="0 0 24 24">
+    <path d="M5.5 3.75h8.25l4.75 4.75V17"/>
+    <path d="M13.5 3.9V8.4h4.4"/>
+    <path d="M8.25 12.25h4M8.25 15.75h2.5"/>
+    <path d="M3.5 20.25h17"/>
+    <path d="M16.4 18.6l4.1-4.1a1.35 1.35 0 0 0-1.9-1.9l-4.1 4.1-.5 2.4z"/>
+  </symbol>
   <symbol id="ic-check" viewBox="0 0 24 24">
     <path d="M5 12.5l4.6 4.6L19 7.6"/>
   </symbol>
@@ -1432,9 +1490,10 @@
 
 <!-- ══ SECTION NAV ══ -->
 <nav id="section-nav">
-  <button class="section-btn" id="sec-btn-home" onclick="switchSection('home')"><svg class="ico" aria-hidden="true"><use href="#ic-star"></use></svg>Home</button>
-  <button class="section-btn active" id="sec-btn-grades" onclick="switchSection('grades')"><svg class="ico" aria-hidden="true"><use href="#ic-grades"></use></svg>Grades</button>
-  <button class="section-btn"        id="sec-btn-tests"  onclick="switchSection('tests')"><svg class="ico" aria-hidden="true"><use href="#ic-tests"></use></svg><span class="nav-full">Standardized Tests</span><span class="nav-short">Tests</span></button>
+  <button class="section-btn" id="sec-btn-home" onclick="switchSection('home')"><svg class="ico" aria-hidden="true"><use href="#ic-star"></use></svg><span class="sec-label">Home</span></button>
+  <button class="section-btn active" id="sec-btn-grades" onclick="switchSection('grades')"><svg class="ico" aria-hidden="true"><use href="#ic-grades"></use></svg><span class="sec-label">Grades</span></button>
+  <button class="section-btn" id="sec-btn-classwork" onclick="switchSection('classwork')"><svg class="ico" aria-hidden="true"><use href="#ic-classwork"></use></svg><span class="sec-label">Classwork</span></button>
+  <button class="section-btn" id="sec-btn-tests" onclick="switchSection('tests')"><svg class="ico" aria-hidden="true"><use href="#ic-tests"></use></svg><span class="sec-label"><span class="nav-full">Standardized Tests</span><span class="nav-short">Test Prep</span></span></button>
 </nav>
 
 <!-- ══ SUBJECT TOGGLE ══ -->
@@ -1613,6 +1672,23 @@
         <div class="home-stats" id="home-stats"></div>
       </div>
     </div>
+  </div>
+
+  <!-- CLASSWORK SCREEN -->
+  <div id="classwork-screen" class="card hidden">
+    <h2 style="text-align:center;margin-bottom:6px;">Classwork</h2>
+    <p style="text-align:center;color:var(--tx-2);font-size:.92rem;margin-bottom:16px;">
+      Worksheets from school. Pick one to work through.
+    </p>
+
+    <div style="display:flex;justify-content:center;margin-bottom:16px;">
+      <div id="classwork-subject-toggle" style="display:inline-flex;gap:4px;background:var(--surface-2);border:1px solid var(--line);border-radius:50px;padding:5px;">
+        <button class="subject-btn active" id="cw-btn-math" onclick="setClassworkSubject('Math')"><svg class="ico" aria-hidden="true"><use href="#ic-math"></use></svg>Math</button>
+        <button class="subject-btn" id="cw-btn-reading" onclick="setClassworkSubject('Reading')"><svg class="ico" aria-hidden="true"><use href="#ic-books"></use></svg>Reading</button>
+      </div>
+    </div>
+
+    <div id="classwork-list"></div>
   </div>
 
   <!-- TEST CONFIG SCREEN -->
@@ -1982,11 +2058,15 @@ const CAT_STYLE = {
 let PASSAGES   = {};  // populated by loadAppData()
 
 // Domain counts for UI (loaded at startup — lightweight, no question content)
-let DOMAIN_COUNTS = {}; // { Math: { All: 1840, OA: 624, ... }, Reading: { All: 50 } }
+let DOMAIN_COUNTS = {}; // active track's counts: { Math: { All, OA, ... }, Reading: {...} }
+let TRACK_COUNTS  = { test_prep: {}, classwork: {} };  // per-track counts
+let ASSIGNMENT_INDEX = { test_prep: {}, classwork: {} }; // { subject: { name: count } }
 
 // Question cache — populated lazily when a session starts, keyed by "Subject_Domain"
 let Q_CACHE = {};
-function _qKey(subj, dom) { return `${subj}_${dom||'All'}`; }
+// Track is part of the key: classwork and test prep must never share a cache
+// entry, or switching sections would serve the wrong question set.
+function _qKey(subj, dom) { return `${activeTrack}_${subj}_${dom||'All'}`; }
 
 // Convert a DB question row to the app's internal format
 function dbToQ(q) {
@@ -1996,6 +2076,7 @@ function dbToQ(q) {
     correct: q.correct,
     hint: q.hint || undefined,
     solution: q.solution || undefined,
+    assignment: q.assignment || null,
   };
   if (q.passage_id) out.passageId = q.passage_id;
   if (q.passage)    out.passage   = q.passage;
@@ -2021,9 +2102,10 @@ async function ensureQuestionsLoaded(subject, domain) {
   // Fetch from Supabase (paginated) — filtered by grade once migration is applied
   const domFilter   = (!domain || domain === 'All') ? '' : `&domain=eq.${encodeURIComponent(domain)}`;
   const gradeFilter = `&grade=eq.${studentGrade}`;
+  const trackFilter = `&track=eq.${activeTrack}`;
   const rows = await _fetchAll(
-    `questions?select=subject,domain,category,type,text,options,correct,hint,solution,passage_id,passage` +
-    `&subject=eq.${encodeURIComponent(subject)}&active=eq.true${gradeFilter}${domFilter}`,
+    `questions?select=subject,domain,category,type,text,options,correct,hint,solution,passage_id,passage,assignment` +
+    `&subject=eq.${encodeURIComponent(subject)}&active=eq.true${gradeFilter}${trackFilter}${domFilter}`,
     h
   );
   Q_CACHE[domKey] = rows.map(dbToQ);
@@ -2132,6 +2214,11 @@ function updateStartScreen() {
 }
 
 function filteredQuestions() {
+  // Classwork is scoped to one worksheet at a time.
+  if (activeTrack === 'classwork' && activeAssignment && activeAssignment !== 'All') {
+    const pool = Q_CACHE[_qKey(activeSubject, 'All')] || [];
+    return pool.filter(q => q.assignment === activeAssignment);
+  }
   // Use the domain-specific cache if available, otherwise filter from 'All'
   const domKey = _qKey(activeSubject, activeDomain);
   if (Q_CACHE[domKey]) return [...Q_CACHE[domKey]];
@@ -2182,7 +2269,14 @@ const MCAP_PRESETS = {
   }
 };
 
-let activeSection = 'grades'; // 'grades' | 'tests'
+let activeSection = 'grades'; // 'grades' | 'home' | 'tests' | 'classwork'
+
+// Which body of work is in play. 'test_prep' is MCAP drill material;
+// 'classwork' is the worksheets that come home from school. They are
+// different activities and are kept fully separate.
+let activeTrack = 'test_prep';   // 'test_prep' | 'classwork'
+let activeAssignment = 'All';    // classwork only: which worksheet
+let ASSIGNMENTS = [];            // [{ name, count }] for the active grade/subject
 let testsMode     = 'practice'; // 'practice' | 'test'
 
 function setTestsMode(mode) {
@@ -2338,21 +2432,114 @@ async function renderHome(force) {
   renderHomeStats(p);
 }
 
+// ═══════════════════════════════════════════════════════════════════
+//  CLASSWORK
+//
+//  Worksheets group by the sheet they came home on, not by CCSS domain.
+//  "Week 3 Fractions" is how the work actually arrives, and it is what
+//  Jaden recognises; a domain code is not.
+// ═══════════════════════════════════════════════════════════════════
+
+let classworkSubject = 'Math';
+
+function setClassworkSubject(subj) {
+  classworkSubject = subj;
+  document.getElementById('cw-btn-math')?.classList.toggle('active', subj === 'Math');
+  document.getElementById('cw-btn-reading')?.classList.toggle('active', subj === 'Reading');
+  renderClasswork();
+}
+
+function renderClasswork() {
+  const host = document.getElementById('classwork-list');
+  if (!host) return;
+
+  const bySubject = (ASSIGNMENT_INDEX.classwork || {})[classworkSubject] || {};
+  const names = Object.keys(bySubject).sort();
+  const loose = ((TRACK_COUNTS.classwork || {})[classworkSubject] || {}).All || 0;
+  const filed = names.reduce((n, k) => n + bySubject[k], 0);
+  const unfiled = Math.max(0, loose - filed);
+
+  if (!names.length && !unfiled) {
+    host.innerHTML = `
+      <div class="cw-empty">
+        <strong>No ${classworkSubject.toLowerCase()} worksheets yet</strong>
+        Worksheets you upload will show up here, grouped by sheet.
+        Test practice stays in Standardized Tests and is not affected.
+      </div>`;
+    return;
+  }
+
+  const rows = names.map(name => `
+    <button class="cw-item" onclick="startAssignment(${JSON.stringify(name).replace(/"/g, '&quot;')})">
+      <span class="cw-item-ico"><svg class="ico" aria-hidden="true"><use href="#ic-classwork"></use></svg></span>
+      <span class="cw-item-body">
+        <span class="cw-item-name">${name}</span>
+        <span class="cw-item-meta">${bySubject[name]} question${bySubject[name] === 1 ? '' : 's'}</span>
+      </span>
+      <svg class="ico cw-item-go" aria-hidden="true"><use href="#ic-arrow"></use></svg>
+    </button>`);
+
+  if (unfiled) {
+    rows.push(`
+      <button class="cw-item" onclick="startAssignment('All')">
+        <span class="cw-item-ico"><svg class="ico" aria-hidden="true"><use href="#ic-all"></use></svg></span>
+        <span class="cw-item-body">
+          <span class="cw-item-name">Everything else</span>
+          <span class="cw-item-meta">${unfiled} question${unfiled === 1 ? '' : 's'} with no worksheet</span>
+        </span>
+        <svg class="ico cw-item-go" aria-hidden="true"><use href="#ic-arrow"></use></svg>
+      </button>`);
+  }
+
+  host.innerHTML = `<div class="cw-list">${rows.join('')}</div>`;
+}
+
+async function startAssignment(name) {
+  activeAssignment = name;
+  activeSubject = classworkSubject;
+  activeDomain  = 'All';
+  practiceQCount = 0;          // a worksheet is worked in full, not sampled
+  await startGame(false);      // and in the order it was printed
+}
+
 function switchSection(sec) {
   activeSection = sec;
-  ['home','grades','tests'].forEach(s =>
+  ['home','grades','classwork','tests'].forEach(s =>
     document.getElementById(`sec-btn-${s}`)?.classList.toggle('active', s === sec));
   // Subject toggle only shown for tests-practice (domain nav handles subject there)
   document.getElementById('subject-toggle').style.display = 'none';
+
+  // Classwork and test prep are separate bodies of work. Switching sections
+  // switches the track, which changes which questions exist at all.
+  const wantTrack = sec === 'classwork' ? 'classwork' : 'test_prep';
+  if (wantTrack !== activeTrack) setTrack(wantTrack);
+
   if (sec === 'grades') {
     show('grades-screen');
   } else if (sec === 'home') {
     show('home-screen');
     renderHome();
+  } else if (sec === 'classwork') {
+    show('classwork-screen');
+    renderClasswork();
   } else {
     show('test-config-screen');
     setTestsMode(testsMode); // restore last sub-mode
   }
+}
+
+// Swapping track invalidates every cached question set and re-points the
+// counts the nav reads from.
+function setTrack(track) {
+  activeTrack = track;
+  activeAssignment = 'All';
+  Object.keys(Q_CACHE).forEach(k => delete Q_CACHE[k]);
+  DOMAIN_COUNTS = TRACK_COUNTS[activeTrack] || {};
+  if (window._mcapData) {
+    window._mcapData.activeTrack   = activeTrack;
+    window._mcapData.DOMAIN_COUNTS = DOMAIN_COUNTS;
+  }
+  buildNav();
 }
 
 async function selectGrade(grade) {
@@ -2380,14 +2567,27 @@ async function selectGrade(grade) {
 
   // Re-fetch domain counts for the selected grade
   const countRows = await _fetchAll(
-    `questions?select=subject,domain&active=eq.true&grade=eq.${grade}`, h);
-  DOMAIN_COUNTS = {};
+    `questions?select=subject,domain,track,assignment&active=eq.true&grade=eq.${grade}`, h);
+  // Counts are kept per track. TRACK_COUNTS[track][subject][domain] so the
+  // nav can show the right totals without a second round trip when the
+  // section changes.
+  TRACK_COUNTS = { test_prep: {}, classwork: {} };
+  ASSIGNMENT_INDEX = { test_prep: {}, classwork: {} };
   for (const r of countRows) {
+    const t = r.track === 'classwork' ? 'classwork' : 'test_prep';
     const s = r.subject || 'Math';
-    if (!DOMAIN_COUNTS[s]) DOMAIN_COUNTS[s] = { All: 0 };
-    DOMAIN_COUNTS[s].All++;
-    DOMAIN_COUNTS[s][r.domain] = (DOMAIN_COUNTS[s][r.domain] || 0) + 1;
+    const bucket = TRACK_COUNTS[t];
+    if (!bucket[s]) bucket[s] = { All: 0 };
+    bucket[s].All++;
+    bucket[s][r.domain] = (bucket[s][r.domain] || 0) + 1;
+
+    if (r.assignment) {
+      const ai = ASSIGNMENT_INDEX[t];
+      if (!ai[s]) ai[s] = {};
+      ai[s][r.assignment] = (ai[s][r.assignment] || 0) + 1;
+    }
   }
+  DOMAIN_COUNTS = TRACK_COUNTS[activeTrack] || {};
 
   _applyGradeLabels();
   // DOMAIN_COUNTS was reassigned above, so the reference captured in _mcapData
@@ -2406,7 +2606,7 @@ async function selectGrade(grade) {
 }
 
 function show(id) {
-  ['start-screen','grades-screen','home-screen','reading-screen','question-screen','end-screen',
+  ['start-screen','grades-screen','home-screen','classwork-screen','reading-screen','question-screen','end-screen',
    'test-config-screen','test-results-screen','history-screen',
    'test-review-screen'].forEach(s=>
     document.getElementById(s).classList.toggle('hidden', s!==id));
@@ -3105,7 +3305,8 @@ async function createAttempt(subject, mode, domain) {
     await fetch(`${SUPABASE_URL}/rest/v1/attempts`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON, 'Authorization': `Bearer ${SUPABASE_ANON}`, 'Prefer': 'return=minimal' },
-      body: JSON.stringify({ id, student: 'Jaden', subject, mode, domain, score: 0, total: 0, pct: 0, time_sec: 0, breakdown: {}, completed: false }),
+      body: JSON.stringify({ id, student: 'Jaden', subject, mode, domain, track: activeTrack,
+                             score: 0, total: 0, pct: 0, time_sec: 0, breakdown: {}, completed: false }),
     });
   } catch(e) {}
   return id;

--- a/migrations/003_classwork_track.sql
+++ b/migrations/003_classwork_track.sql
@@ -1,0 +1,29 @@
+-- ============================================================
+-- Migration: separate regular classwork from standardized test prep
+--
+-- `source` already exists but describes PROVENANCE
+-- ('manual' | 'packet' | 'ai-generated'). A scanned worksheet and a
+-- scanned MCAP page are both 'packet', so it cannot express PURPOSE.
+-- `track` is the orthogonal dimension.
+-- ============================================================
+
+ALTER TABLE questions
+  ADD COLUMN IF NOT EXISTS track      text NOT NULL DEFAULT 'test_prep',
+  ADD COLUMN IF NOT EXISTS assignment text;
+
+-- Every existing question is MCAP material, so the default backfills correctly.
+UPDATE questions SET track = 'test_prep' WHERE track IS NULL;
+
+ALTER TABLE questions
+  DROP CONSTRAINT IF EXISTS questions_track_check;
+ALTER TABLE questions
+  ADD CONSTRAINT questions_track_check CHECK (track IN ('test_prep','classwork'));
+
+CREATE INDEX IF NOT EXISTS idx_questions_track ON questions(grade, track, subject);
+
+-- Sessions record which track they belong to so progress and the parent
+-- dashboard can report classwork and test prep separately.
+ALTER TABLE attempts
+  ADD COLUMN IF NOT EXISTS track text NOT NULL DEFAULT 'test_prep';
+
+CREATE INDEX IF NOT EXISTS idx_attempts_track ON attempts(student, track, created_at DESC);

--- a/tests.html
+++ b/tests.html
@@ -53,6 +53,29 @@ function db(path, opts = {}) {
   return fetch(`${SUPABASE_URL}/rest/v1/${path}`, { headers: HEADERS, ...opts });
 }
 
+async function dbCount(path) {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    headers: { ...HEADERS, 'Prefer': 'count=exact', 'Range': '0-0' } });
+  assert(res.ok, `HTTP ${res.status}`);
+  return parseInt((res.headers.get('Content-Range') || '').split('/')[1] || '0', 10);
+}
+
+// PostgREST returns at most 1000 rows per page whatever limit is requested,
+// so anything counting the full bank must page rather than ask for 5000.
+async function dbAll(path) {
+  let rows = [], off = 0;
+  while (true) {
+    const sep = path.includes('?') ? '&' : '?';
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}${sep}order=id&offset=${off}&limit=1000`,
+      { headers: HEADERS });
+    assert(res.ok, `HTTP ${res.status}`);
+    const b = await res.json();
+    rows = rows.concat(b);
+    if (b.length < 1000) return rows;
+    off += 1000;
+  }
+}
+
 function makeAttemptId() {
   return crypto.randomUUID();  // must be valid uuid — track by student='__test__' instead
 }
@@ -643,6 +666,63 @@ create policy "Allow delete wrong_answers"  on wrong_answers for delete using (t
   // Pre-load question data for suites 13 & 14 (lazy-loaded in new architecture)
   await appIframe.ensureQuestionsLoaded('Math', 'All');
   await appIframe.ensureQuestionsLoaded('Reading', 'All');
+
+  // ── Classwork vs test prep separation ────────────────────────────────────
+  suite('\u{1F4DA} Track separation \u2014 classwork vs test prep');
+
+  await test('questions has track + assignment columns', async () => {
+    const res = await db('questions?select=track,assignment&limit=1');
+    assert(res.ok, `HTTP ${res.status}`);
+    const rows = await res.json();
+    assert(rows.length && 'track' in rows[0] && 'assignment' in rows[0],
+      `missing columns: ${JSON.stringify(rows[0])}`);
+    return 'track + assignment present';
+  });
+
+  await test('attempts has a track column', async () => {
+    const res = await db('attempts?select=track&limit=1');
+    assert(res.ok, `HTTP ${res.status}`);
+    const rows = await res.json();
+    assert(rows.length && 'track' in rows[0], 'attempts.track missing');
+    return 'attempts.track present';
+  });
+
+  await test('track only ever holds test_prep or classwork', async () => {
+    const rows = await dbAll('questions?select=track&active=eq.true');
+    const bad = [...new Set(rows.map(r => r.track))].filter(t => !['test_prep','classwork'].includes(t));
+    assert(bad.length === 0, `unexpected track values: ${JSON.stringify(bad)}`);
+    return `${rows.length} active questions, tracks: ${[...new Set(rows.map(r=>r.track))].join(', ')}`;
+  });
+
+  await test('the two tracks are disjoint - no question is in both', async () => {
+    const tp = await dbAll('questions?select=id&active=eq.true&track=eq.test_prep');
+    const cw = await dbAll('questions?select=id&active=eq.true&track=eq.classwork');
+    const tpIds = new Set(tp.map(r => r.id));
+    const overlap = cw.filter(r => tpIds.has(r.id));
+    assert(overlap.length === 0, `${overlap.length} questions appear in both tracks`);
+    const total = await dbCount('questions?select=id&active=eq.true');
+    assert(tp.length + cw.length === total,
+      `tracks sum to ${tp.length + cw.length} but there are ${total} active questions`);
+    return `${tp.length} test prep + ${cw.length} classwork = ${total}, disjoint`;
+  });
+
+  await test('classwork questions carry an assignment so they can be grouped', async () => {
+    const cw = await (await db('questions?select=id,assignment&active=eq.true&track=eq.classwork&limit=1000')).json();
+    if (!cw.length) return 'no classwork loaded yet';
+    const unfiled = cw.filter(r => !r.assignment);
+    // Unfiled classwork is allowed - it falls into "Everything else" - but it
+    // should be the exception, not the rule.
+    assert(unfiled.length < cw.length,
+      `all ${cw.length} classwork questions are missing an assignment`);
+    return `${cw.length} classwork questions, ${cw.length - unfiled.length} filed to a worksheet`;
+  });
+
+  await test('test-prep practice is unaffected by the split', async () => {
+    // The whole pre-existing bank must still be reachable as test prep.
+    const n = await dbCount('questions?select=id&active=eq.true&track=eq.test_prep&grade=eq.3&subject=eq.Math');
+    assert(n >= 1800, `expected the grade 3 Math bank intact, got ${n}`);
+    return `${n} grade 3 Math test-prep questions still present`;
+  });
 
   // ── Progress engine (pure functions, via iframe) ─────────────────────────
   suite('\u{1F3AE} Progress engine \u2014 XP, levels, streaks (iframe)');

--- a/upload_classwork.py
+++ b/upload_classwork.py
@@ -1,0 +1,110 @@
+"""
+Upload a classwork worksheet.
+
+Classwork is kept separate from standardized test prep by the `track` column:
+  track='classwork'  -> shows under the Classwork section, grouped by worksheet
+  track='test_prep'  -> MCAP drill material (everything that existed before)
+
+Edit ASSIGNMENT / GRADE / SUBJECT and the QUESTIONS list, then run:
+
+    python3 upload_classwork.py            # dry run, prints what would upload
+    python3 upload_classwork.py --apply    # actually write
+
+To remove a worksheet you uploaded by mistake:
+
+    python3 upload_classwork.py --delete "Week 3 - Multiplication"
+"""
+import json, sys, urllib.request, urllib.parse
+
+BASE = "https://zvffmucghcrqackghhlf.supabase.co/rest/v1"
+KEY  = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Inp2ZmZtdWNnaGNycWFja2doaGxmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NzY3MjkyNTIsImV4cCI6MjA5MjMwNTI1Mn0.eJHX6LmInRdBd5nt9t_jBJwILGEQ6_SeN6ADorlsWic"
+H    = {"Content-Type": "application/json", "apikey": KEY, "Authorization": f"Bearer {KEY}"}
+
+# ── edit these ───────────────────────────────────────────────────────────
+GRADE      = 4
+SUBJECT    = "Math"                      # "Math" | "Reading"
+ASSIGNMENT = "Week 5 - Division"         # the name on the sheet
+DOMAIN     = "NBT"                       # OA | NBT | NF | MD | G | RL | RI | L
+CATEGORY   = "Division"                  # free text, shown as the chip
+
+QUESTIONS = [
+    # multiple choice: options + correct letter
+    {"type": "single", "text": "What is 144 divided by 12?",
+     "options": ["11", "12", "13", "14"], "correct": ["B"],
+     "hint": "12 x 12 = 144"},
+
+    # numeric: no options, correct is the number
+    {"type": "numeric", "text": "What is 96 divided by 8?",
+     "options": None, "correct": "12",
+     "hint": "8 x 12 = 96"},
+]
+# ─────────────────────────────────────────────────────────────────────────
+
+# Never upload options with letter prefixes baked in - the app shuffles
+# options and draws its own A/B/C/D badge, so a baked-in letter contradicts
+# the badge once the order changes. See issue #29.
+_LETTERS, _SEPS = "ABCDEFGH", (" ", ".", ")", "-", ":")
+
+def strip_option_prefixes(options):
+    if not isinstance(options, list) or len(options) < 2:
+        return options
+    def cut(o, ch):
+        if not isinstance(o, str):
+            return None
+        t = o.lstrip()
+        return t[2:].lstrip(" .)-:") if len(t) >= 2 and t[0] == ch and t[1] in _SEPS else None
+    hits = sum(1 for i, o in enumerate(options) if i < len(_LETTERS) and cut(o, _LETTERS[i]) is not None)
+    if hits < max(3, len(options) - 1):
+        return options
+    return [(cut(o, _LETTERS[i]) if i < len(_LETTERS) else None) or o for i, o in enumerate(options)]
+
+
+def rows():
+    out = []
+    for q in QUESTIONS:
+        out.append({
+            "grade": GRADE, "subject": SUBJECT, "domain": DOMAIN,
+            "category": q.get("category", CATEGORY),
+            "type": q["type"], "text": q["text"],
+            "options": strip_option_prefixes(q.get("options")),
+            "correct": q["correct"], "hint": q.get("hint"),
+            "solution": q.get("solution"),
+            "active": True, "source": "manual",
+            "track": "classwork", "assignment": ASSIGNMENT,
+        })
+    return out
+
+
+def post(batch):
+    req = urllib.request.Request(f"{BASE}/questions", data=json.dumps(batch).encode(),
+                                 method="POST", headers={**H, "Prefer": "return=minimal"})
+    with urllib.request.urlopen(req) as r:
+        return r.status
+
+
+def delete(name):
+    q = urllib.parse.quote(name)
+    req = urllib.request.Request(
+        f"{BASE}/questions?track=eq.classwork&assignment=eq.{q}",
+        method="DELETE", headers={**H, "Prefer": "return=minimal"})
+    with urllib.request.urlopen(req) as r:
+        return r.status
+
+
+if "--delete" in sys.argv:
+    name = sys.argv[sys.argv.index("--delete") + 1]
+    print(f"deleting worksheet {name!r}: HTTP {delete(name)}")
+    sys.exit(0)
+
+batch = rows()
+print(f"{ASSIGNMENT}  ({SUBJECT}, grade {GRADE}) - {len(batch)} questions")
+for r in batch:
+    print(f"  [{r['type']:7}] {r['text'][:66]}")
+    if r["options"]:
+        print(f"            {r['options']}  -> {r['correct']}")
+
+if "--apply" not in sys.argv:
+    print("\nDRY RUN. Re-run with --apply to upload.")
+    sys.exit(0)
+
+print(f"\nHTTP {post(batch)} - uploaded")


### PR DESCRIPTION
Closes #39

Everything in the app was MCAP drill material. Worksheets from school are a **different activity** — "the homework in front of me tonight" rather than "drill this domain until it sticks" — and mixing them would make both worse.

## Why not reuse `source`
`questions.source` already exists (`'manual' | 'packet' | 'ai-generated'`) but describes **provenance**, not **purpose**. A scanned worksheet and a scanned MCAP page would both be `'packet'` and become indistinguishable. Orthogonal dimensions, separate columns.

## Model
- `questions.track` — `'test_prep' | 'classwork'`, defaults to `test_prep`, CHECK-constrained
- `questions.assignment` — nullable, the name on the sheet
- `attempts.track` — so progress and the parent dashboard can report them separately

All **2,176 existing questions backfilled to `test_prep`**, which is correct — it is all MCAP material.

## Design calls
**Classwork groups by worksheet, not by CCSS domain.** "Week 3 — Multiplication" is how the work arrives and what Jaden recognises; `NBT` is not.

**A worksheet is worked in full, in printed order** — no shuffling, no sampling. Test prep keeps its shuffle.

**`Q_CACHE` keys include the track**, so the two can never share a cache entry and serve the wrong set across a section switch. Verified: after running a worksheet and switching back, the cache holds only `test_prep_Math_NBT` and test-prep results carry no assignment.

## Nav
Four sections no longer fit a phone. Below 470px only the active tab keeps its label and the rest go icon-only — guarantees a fit rather than pushing the last tab off-screen where nobody finds it. Verified `navFits: true`, `lastTabFullyVisible: true` at 375px.

## Two of my own tests were wrong first
`limit=5000` does **not** override PostgREST's 1000-row page cap, so a bank-wide assertion was silently checking only the first 1000 rows — one failed loudly, one *passed* while testing far less than it claimed. Both now page properly or use an exact `Content-Range` count. They report real numbers: **2176 test prep + 6 classwork = 2182, disjoint**, and **1840 grade-3 Math test-prep questions still present**.

## Loading worksheets
`upload_classwork.py` — dry-run by default, `--apply` to write, `--delete "<name>"` to remove one. It carries the same option-prefix guard from #29.

Photo/OCR ingestion stays with #3; this makes the destination exist.

## Sample data
I seeded 6 questions across three worksheets so the screen has something to show, all prefixed **"Sample - "** so they cannot be mistaken for Jaden's real work. Remove them any time:

```bash
python3 upload_classwork.py --delete "Sample - Week 3 - Multiplication"
```

**142/142 tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)